### PR TITLE
pure phases (and functions, by proxy)

### DIFF
--- a/examples/basic-example.xml
+++ b/examples/basic-example.xml
@@ -17,20 +17,57 @@
     </nonChemicalPotentials>
 
     <systemComponents>
-        <systemComponent id="cmpVa" symbol="Va" />
-        <systemComponent id="cmpMo" symbol="Mo" refstate="BCC_A2" molar_mass="95.940" h298="4589.0" s298="28.560" />
-        <systemComponent id="cmpRe" symbol="Re" refstate="HCP_A3" molar_mass="186.21" h298="5355.5" s298="36.526" />
-        <systemComponent id="cmpSi" symbol="Si" refstate="???"    molar_mass="28.0855" h298="0.0"   s298="1.234" />
-        <systemComponent id="cmpO"  symbol="O"  refstate="???"    molar_mass="15.9994" h298="0.0"   s298="2.345" />
+        <systemComponent  symbol="Va" />
+        <systemComponent  symbol="Mo" refstate="BCC_A2" molar_mass="95.940"  h298="4589.0" s298="28.560" />
+        <systemComponent  symbol="Re" refstate="HCP_A3" molar_mass="186.21"  h298="5355.5" s298="36.526" />
+        <systemComponent  symbol="Cr" refstate="BCC_A2" molar_mass="51.996"  h298="4050.0" s298="23.5429" />
+        <systemComponent  symbol="Ni" refstate="FCC_A1" molar_mass="58.69"   h298="4787.0" s298="29.7955" />
+        <systemComponent  symbol="Si" refstate="???"    molar_mass="28.0855" h298="0.0"    s298="1.234" />
+        <systemComponent  symbol="O"  refstate="???"    molar_mass="15.9994" h298="0.0"    s298="2.345" />
     </systemComponents>
 
     <phases>
         <phase id="phaQuartz" name="SiO2(quartz)" state="solid" xsi:type="PurePhaseType">
             <stoichiometry>
-                <stoich component="cmpSi" coeff="1"/>
-                <stoich component="cmpO"  coeff="2"/>
+                <stoich component="Si" coeff="1"/>
+                <stoich component="O"  coeff="2"/>
             </stoichiometry>
+            <energy type="h-s-cp" factor="1" name="SiO2#quartz" />
+        </phase>
+        
+        <phase id="phaNi" name="Ni(BCC_A2)" state="solid" xsi:type="PurePhaseType">
+            <stoichiometry>
+                <stoich component="Ni" coeff="1"/>
+            </stoichiometry>
+            <energy type="tdb" factor="1" name="GHSERNI" />
         </phase>
     </phases>
+
+    <functions>
+        <hscp name="SiO2#quartz">
+            <h298 value="-910699.94184" />
+            <s298 value="41.4600015888" />
+            <Range low="298.15" high="373.0">
+                <term coeff="80.0119918" fun="T^0" />
+                <term coeff="-3546683.99888" fun="T^(-2)" />
+                <term coeff="-240.275998928" fun="T^(-0.5)" />
+                <term coeff="491568369.44" fun="T^(-3)" />
+            </Range>
+        </hscp>
+        <tdb name="GHSERNI">
+            298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
+            1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
+            3000.00  N !
+        </tdb>
+        <chemsage name="Cr#FCC_A1">
+            4 2 
+            1478.0000     -1490500.2      1740.8682     -248.92708      0.0000000    
+            0.0000000      0.0000000    
+           2 -7695.4098       0.50  23184001.      -2.00
+            1550.0000     -1626055.5      1571.5021     -240.58000      0.0000000    
+            0.0000000      0.0000000    
+           1  0.0000000       0.00
+        </chemsage>
+    </functions>
 
 </database>

--- a/examples/basic-example.xml
+++ b/examples/basic-example.xml
@@ -32,20 +32,22 @@
                 <stoich component="Si" coeff="1"/>
                 <stoich component="O"  coeff="2"/>
             </stoichiometry>
-            <energyRef type="h-s-cp" factor="1" name="SiO2#quartz" />
+            <property type="free-energy" function_of="T">
+                <reference type="h-s-cp" factor="1" name="SiO2#quartz" />
+            </property>
         </phase>
 
-        <phase id="phaNi" name="Ni(BCC_A2)" state="solid" xsi:type="PurePhaseType">
+        <phase id="phaNi" name="Ni(FCC_A1)" state="solid" xsi:type="PurePhaseType">
             <stoichiometry>
                 <stoich component="Ni" coeff="1"/>
             </stoichiometry>
-            <energy>
+            <property type="free-energy" function_of="T">
                 <tdb name="GHSERNI">
                     298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
                     1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
                     3000.00  N !
                 </tdb>
-            </energy>
+            </property>
         </phase>
     </phases>
 

--- a/examples/basic-example.xml
+++ b/examples/basic-example.xml
@@ -32,7 +32,7 @@
                 <stoich component="Si" coeff="1"/>
                 <stoich component="O"  coeff="2"/>
             </stoichiometry>
-            <property type="free-energy" function_of="T">
+            <property type="G">
                 <reference type="h-s-cp" factor="1" name="SiO2#quartz" />
             </property>
         </phase>
@@ -41,7 +41,7 @@
             <stoichiometry>
                 <stoich component="Ni" coeff="1"/>
             </stoichiometry>
-            <property type="free-energy" function_of="T">
+            <property type="G">
                 <tdb name="GHSERNI">
                     298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
                     1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
@@ -52,6 +52,11 @@
     </phases>
 
     <functions>
+        <expr name="SiO2#other_func">
+            <range low="298.15" high="373.0">
+                80.0119918*T^0 + -3546683.99888*T^(-2) + -240.275998928*T^(-0.5) + 491568369.44*T^(-3)
+            </range>
+        </expr>
         <hscp name="SiO2#quartz">
             <h298 value="-910699.94184" />
             <s298 value="41.4600015888" />

--- a/examples/basic-example.xml
+++ b/examples/basic-example.xml
@@ -42,22 +42,24 @@
                 <stoich component="Ni" coeff="1"/>
             </stoichiometry>
             <property type="G">
-                <tdb name="GHSERNI">
-                    298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
-                    1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
-                    3000.00  N !
-                </tdb>
+                <function name="GHSERNI" xsi:type="FunctionTypeTDB">
+                    <tdb>
+                        298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
+                        1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
+                        3000.00  N !
+                    </tdb>
+                </function>
             </property>
         </phase>
     </phases>
 
     <functions>
-        <expr name="SiO2#other_func">
-            <range low="298.15" high="373.0">
+        <function name="SiO2#other_func" xsi:type="FunctionTypeExpr">
+            <range low="298.15" high="373.0" >
                 80.0119918*T^0 + -3546683.99888*T^(-2) + -240.275998928*T^(-0.5) + 491568369.44*T^(-3)
             </range>
-        </expr>
-        <hscp name="SiO2#quartz">
+        </function>
+        <function name="SiO2#quartz" xsi:type="FunctionTypeHSCP">
             <h298 value="-910699.94184" />
             <s298 value="41.4600015888" />
             <range low="298.15" high="373.0">
@@ -66,21 +68,25 @@
                 <term coeff="-240.275998928" fun="T^(-0.5)" />
                 <term coeff="491568369.44" fun="T^(-3)" />
             </range>
-        </hscp>
-        <tdb name="GHSERNI">
-            298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
-            1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
-            3000.00  N !
-        </tdb>
-        <chemsage name="Cr#FCC_A1">
-            4 2 
-            1478.0000     -1490500.2      1740.8682     -248.92708      0.0000000    
-            0.0000000      0.0000000    
-           2 -7695.4098       0.50  23184001.      -2.00
-            1550.0000     -1626055.5      1571.5021     -240.58000      0.0000000    
-            0.0000000      0.0000000    
-           1  0.0000000       0.00
-        </chemsage>
+        </function>
+        <function name="GHSERNI" xsi:type="FunctionTypeTDB">
+            <tdb>
+                298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
+                1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
+                3000.00  N !
+            </tdb>
+        </function>
+        <function name="Cr#FCC_A1" xsi:type="FunctionTypeCSdat">
+            <chemsage>
+                4 2     
+                1478.0000     -1490500.2      1740.8682     -248.92708      0.0000000    
+                0.0000000      0.0000000    
+                2 -7695.4098       0.50  23184001.      -2.00
+                1550.0000     -1626055.5      1571.5021     -240.58000      0.0000000    
+                0.0000000      0.0000000    
+                1  0.0000000       0.00
+            </chemsage>
+        </function>
     </functions>
 
 </database>

--- a/examples/basic-example.xml
+++ b/examples/basic-example.xml
@@ -17,17 +17,17 @@
     </nonChemicalPotentials>
 
     <systemComponents>
-        <systemComponent  symbol="Va" />
-        <systemComponent  symbol="Mo" refstate="BCC_A2" molar_mass="95.940"  h298="4589.0" s298="28.560" />
-        <systemComponent  symbol="Re" refstate="HCP_A3" molar_mass="186.21"  h298="5355.5" s298="36.526" />
-        <systemComponent  symbol="Cr" refstate="BCC_A2" molar_mass="51.996"  h298="4050.0" s298="23.5429" />
-        <systemComponent  symbol="Ni" refstate="FCC_A1" molar_mass="58.69"   h298="4787.0" s298="29.7955" />
-        <systemComponent  symbol="Si" refstate="???"    molar_mass="28.0855" h298="0.0"    s298="1.234" />
-        <systemComponent  symbol="O"  refstate="???"    molar_mass="15.9994" h298="0.0"    s298="2.345" />
+        <systemComponent symbol="Va" />
+        <systemComponent symbol="Mo" refstate="BCC_A2" molar_mass="95.940"  h298="4589.0" s298="28.560" />
+        <systemComponent symbol="Re" refstate="HCP_A3" molar_mass="186.21"  h298="5355.5" s298="36.526" />
+        <systemComponent symbol="Cr" refstate="BCC_A2" molar_mass="51.996"  h298="4050.0" s298="23.5429" />
+        <systemComponent symbol="Ni" refstate="FCC_A1" molar_mass="58.69"   h298="4787.0" s298="29.7955" />
+        <systemComponent symbol="Si" refstate="???"    molar_mass="28.0855" h298="0.0"    s298="1.234" />
+        <systemComponent symbol="O"  refstate="???"    molar_mass="15.9994" h298="0.0"    s298="2.345" />
     </systemComponents>
 
     <phases>
-        <phase id="phaQuartz" name="SiO2(quartz)" state="solid" xsi:type="PurePhaseType">
+        <phase name="SiO2(quartz)" alias="Amirite(NotReal)" state="solid" xsi:type="PurePhaseType">
             <stoichiometry>
                 <stoich component="Si" coeff="1"/>
                 <stoich component="O"  coeff="2"/>
@@ -37,7 +37,7 @@
             </property>
         </phase>
 
-        <phase id="phaNi" name="Ni(FCC_A1)" state="solid" xsi:type="PurePhaseType">
+        <phase name="Ni(FCC_A1)" state="solid" xsi:type="PurePhaseType">
             <stoichiometry>
                 <stoich component="Ni" coeff="1"/>
             </stoichiometry>

--- a/examples/basic-example.xml
+++ b/examples/basic-example.xml
@@ -17,20 +17,63 @@
     </nonChemicalPotentials>
 
     <systemComponents>
-        <systemComponent id="cmpVa" symbol="Va" />
-        <systemComponent id="cmpMo" symbol="Mo" refstate="BCC_A2" molar_mass="95.940" h298="4589.0" s298="28.560" />
-        <systemComponent id="cmpRe" symbol="Re" refstate="HCP_A3" molar_mass="186.21" h298="5355.5" s298="36.526" />
-        <systemComponent id="cmpSi" symbol="Si" refstate="???"    molar_mass="28.0855" h298="0.0"   s298="1.234" />
-        <systemComponent id="cmpO"  symbol="O"  refstate="???"    molar_mass="15.9994" h298="0.0"   s298="2.345" />
+        <systemComponent  symbol="Va" />
+        <systemComponent  symbol="Mo" refstate="BCC_A2" molar_mass="95.940"  h298="4589.0" s298="28.560" />
+        <systemComponent  symbol="Re" refstate="HCP_A3" molar_mass="186.21"  h298="5355.5" s298="36.526" />
+        <systemComponent  symbol="Cr" refstate="BCC_A2" molar_mass="51.996"  h298="4050.0" s298="23.5429" />
+        <systemComponent  symbol="Ni" refstate="FCC_A1" molar_mass="58.69"   h298="4787.0" s298="29.7955" />
+        <systemComponent  symbol="Si" refstate="???"    molar_mass="28.0855" h298="0.0"    s298="1.234" />
+        <systemComponent  symbol="O"  refstate="???"    molar_mass="15.9994" h298="0.0"    s298="2.345" />
     </systemComponents>
 
     <phases>
         <phase id="phaQuartz" name="SiO2(quartz)" state="solid" xsi:type="PurePhaseType">
             <stoichiometry>
-                <stoich component="cmpSi" coeff="1"/>
-                <stoich component="cmpO"  coeff="2"/>
+                <stoich component="Si" coeff="1"/>
+                <stoich component="O"  coeff="2"/>
             </stoichiometry>
+            <energyRef type="h-s-cp" factor="1" name="SiO2#quartz" />
+        </phase>
+
+        <phase id="phaNi" name="Ni(BCC_A2)" state="solid" xsi:type="PurePhaseType">
+            <stoichiometry>
+                <stoich component="Ni" coeff="1"/>
+            </stoichiometry>
+            <energy>
+                <tdb name="GHSERNI">
+                    298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
+                    1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
+                    3000.00  N !
+                </tdb>
+            </energy>
         </phase>
     </phases>
+
+    <functions>
+        <hscp name="SiO2#quartz">
+            <h298 value="-910699.94184" />
+            <s298 value="41.4600015888" />
+            <range low="298.15" high="373.0">
+                <term coeff="80.0119918" fun="T^0" />
+                <term coeff="-3546683.99888" fun="T^(-2)" />
+                <term coeff="-240.275998928" fun="T^(-0.5)" />
+                <term coeff="491568369.44" fun="T^(-3)" />
+            </range>
+        </hscp>
+        <tdb name="GHSERNI">
+            298.15  -5179.159+117.854*T-22.096*T*LN(T)-0.0048407*T**2;
+            1728.00  Y  -27840.62+279.134977*T-43.1*T*LN(T)+1.12754E+31*T**(-9);
+            3000.00  N !
+        </tdb>
+        <chemsage name="Cr#FCC_A1">
+            4 2 
+            1478.0000     -1490500.2      1740.8682     -248.92708      0.0000000    
+            0.0000000      0.0000000    
+           2 -7695.4098       0.50  23184001.      -2.00
+            1550.0000     -1626055.5      1571.5021     -240.58000      0.0000000    
+            0.0000000      0.0000000    
+           1  0.0000000       0.00
+        </chemsage>
+    </functions>
 
 </database>

--- a/schema/databases/main.xsd
+++ b/schema/databases/main.xsd
@@ -46,6 +46,7 @@
             <xs:element name="functions" minOccurs="0">
                 <xs:complexType>
                     <xs:choice maxOccurs="unbounded">        
+                        <xs:element name="expr" type="FunctionTypeExpr"/>
                         <xs:element name="hscp" type="FunctionTypeHSCP"/>
                         <xs:element name="tdb" type="FunctionTypeTDB"/>
                         <xs:element name="chemsage" type="FunctionTypeCSdat"/>

--- a/schema/databases/main.xsd
+++ b/schema/databases/main.xsd
@@ -46,10 +46,7 @@
             <xs:element name="functions" minOccurs="0">
                 <xs:complexType>
                     <xs:choice maxOccurs="unbounded">        
-                        <xs:element name="expr" type="FunctionTypeExpr"/>
-                        <xs:element name="hscp" type="FunctionTypeHSCP"/>
-                        <xs:element name="tdb" type="FunctionTypeTDB"/>
-                        <xs:element name="chemsage" type="FunctionTypeCSdat"/>
+                        <xs:element name="function" type="AbstractFunctionType"/>
                     </xs:choice>
                 </xs:complexType>
             </xs:element>

--- a/schema/databases/main.xsd
+++ b/schema/databases/main.xsd
@@ -43,6 +43,16 @@
                 </xs:complexType>
             </xs:element>
 
+            <xs:element name="functions" minOccurs="0">
+                <xs:complexType>
+                    <xs:choice maxOccurs="unbounded">        
+                        <xs:element name="hscp" type="FunctionTypeHSCP"/>
+                        <xs:element name="tdb" type="FunctionTypeTDB"/>
+                        <xs:element name="chemsage" type="FunctionTypeCSdat"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" />
     </xs:complexType>

--- a/schema/phases/core.xsd
+++ b/schema/phases/core.xsd
@@ -106,7 +106,34 @@
         <xs:list>
             <xs:simpleType>
                 <xs:restriction base="xs:string">
-                    <xs:enumeration value="free-energy" />
+                    <xs:enumeration value="G">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Gibbs energy
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="BMAG">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Bohr magneton
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="TC">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Curie Temperature
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="TN">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Neel Temperature
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                     <!--  this is where additional properties should go. -->
                 </xs:restriction>
             </xs:simpleType>

--- a/schema/phases/core.xsd
+++ b/schema/phases/core.xsd
@@ -32,6 +32,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="alias"   type="xs:string"        use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Any alias phase names, a comma separated list.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="state"  type="MatterStateType"  use="required">
             <xs:annotation>
                 <xs:documentation xml:lang="en">

--- a/schema/phases/core.xsd
+++ b/schema/phases/core.xsd
@@ -97,18 +97,53 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:simpleType name="PhasePropertyType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A fixed list of available phase properties. 
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="free-energy" />
+                    <!--  this is where additional properties should go. -->
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:simpleType name="FunctionVariableType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A fixed list of available function variables. 
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="T" />
+                    <xs:enumeration value="P" />
+                    <xs:enumeration value="T,P" />
+                    <!-- To be extended -->
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+
+    </xs:simpleType>
+
     <xs:simpleType name="FunctionIDType">
         <xs:annotation>
             <xs:documentation xml:lang="en">
-                Name to identify a function. Certain restrictions may apply,
-                vendor specifically.
+                Name to identify a function. Certain vendor specific
+                restrictions may apply.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
             <!-- This pattern makes sure that if a '#' is used, it has to be "in
-                the middle" of the pattern. E.g. SiO2#quartz is ok, MgCl2# is not. TODO there
-                may be more characters to consider: -_/. ? -->
-            <xs:pattern value="[A-Z][A-Za-z0-9]*#?[A-Za-z0-9_]+" />
+the middle" of the pattern. E.g. SiO2#quartz is ok, MgCl2# is not. TODO there
+may be more characters to consider: -_/. ? -->
+            <xs:pattern value="[A-Z][A-Za-z0-9_]*#?[A-Za-z0-9_]+" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/schema/phases/core.xsd
+++ b/schema/phases/core.xsd
@@ -11,22 +11,11 @@
     <xs:simpleType name="PhaseIdType">
         <xs:annotation>
             <xs:documentation xml:lang="en">
-                A unique identifier for phases.
+                An identifier for phases.
             </xs:documentation>
         </xs:annotation>
-        <xs:restriction base="xs:ID">
-            <xs:pattern value="pha[A-Z][A-Za-z]*" />
-        </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="PhaseIdRefType">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                A unique identifier reference for phases.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:restriction base="xs:IDREF">
-            <xs:pattern value="pha[A-Z][A-Za-z]*" />
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z][A-Za-z]*" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -36,13 +25,6 @@
                 A collection of matter in a single physical state, immiscible with other phases.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="id"     type="PhaseIdType"      use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    The id used to uniquely identify a phase in an XML file.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="name"   type="xs:string"        use="required">
             <xs:annotation>
                 <xs:documentation xml:lang="en">
@@ -65,7 +47,7 @@
                 Used to specify the content of a system component in a phase constituent.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="component"    type="SystemComponentIdRefType"  use="required">
+        <xs:attribute name="component"    type="SystemComponentIdType"  use="required">
             <xs:annotation>
                 <xs:documentation xml:lang="en">
                     System component ID.

--- a/schema/phases/core.xsd
+++ b/schema/phases/core.xsd
@@ -81,4 +81,35 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:complexType name="EnergyFunctionType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Used to specify the energy of a phase. This should list all the
+                possible energy function types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="coeff"  type="xs:float"                  use="optional"  default="1.0">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Stoichiometry coefficient in mol per mole of phase constituent.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="FunctionIDType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Name to identify a function. Certain restrictions may apply,
+                vendor specifically.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <!-- This pattern makes sure that if a '#' is used, it has to be "in
+                the middle" of the pattern. E.g. SiO2#quartz is ok, MgCl2# is not. TODO there
+                may be more characters to consider: -_/. ? -->
+            <xs:pattern value="[A-Z][A-Za-z0-9]*#?[A-Za-z0-9_]+" />
+        </xs:restriction>
+    </xs:simpleType>
+
 </xs:schema>

--- a/schema/phases/functions.xsd
+++ b/schema/phases/functions.xsd
@@ -59,17 +59,34 @@
     </xs:complexType>
 
 
+    <xs:complexType name="AbstractFunctionType" abstract="true">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                An abstract function type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" use="required" type="FunctionIDType" />
+    </xs:complexType>
+
     <xs:complexType  name="FunctionTypeExpr">
-    <xs:annotation>
-        <xs:documentation>
-            A temperature dependent function that is stored in strict ThermML expression style.
-        </xs:documentation>
-        
-    </xs:annotation>
-    <xs:sequence>
-        <xs:element name="range" type="FunctionTypeExprRange" minOccurs="1" maxOccurs="unbounded"/>
-    </xs:sequence>
-    <xs:attribute name="name" type="FunctionIDType" use="required" />
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A temperature dependent function that is stored in strict ThermML expression style.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+
+            <xs:extension base="AbstractFunctionType">
+                <xs:sequence>
+                    <xs:element name="range" type="FunctionTypeExprRange" minOccurs="1" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>A temperature range expression.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+
+            </xs:complexContent>
     
     </xs:complexType>   
 
@@ -79,9 +96,33 @@
                 A term in a H-S-CP function.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="coeff" use="required" type="xs:double"/>
-        <xs:attribute name="fun" use="required" type="xs:string"/>
+
+        <xs:attribute name="coeff" use="required" type="xs:double">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Coefficient of the term. A simple floating point number.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fun" use="required" type="FunctionHSCPTempTermType"/>
+
     </xs:complexType>
+
+    <xs:simpleType name="FunctionHSCPTempTermType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Temperature exponent term in a H-S-CP function. Has to be T^('number').
+
+                For integers &gt;= 0, the brackets can be omitted. (e.g. T^5)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <!-- CAUTION: This regex isn't properly matching actual floating point 
+             numbers as exponents, only the general shape for this term. 
+             For positive integers, the brackets can be omitted. -->
+            <xs:pattern value="T\^\(-?[0-9.]*\)|T\^[0-9]*" /> 
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType  name="FunctionTypeHSCP">
         <xs:annotation>
@@ -89,6 +130,10 @@
                 A H-S-CP function. 
             </xs:documentation>
         </xs:annotation>
+        <xs:complexContent>
+
+        <xs:extension base="AbstractFunctionType">
+
         <xs:sequence>
         <xs:element name="h298">
             <xs:complexType>
@@ -110,24 +155,34 @@
             </xs:complexType>
           </xs:element>
         </xs:sequence>
-        <xs:attribute name="name" use="required" type="FunctionIDType"/>
+        </xs:extension>
+        </xs:complexContent>
     </xs:complexType>   
 
+    <!-- As is, this can not inherit from the abstract Function Type, as it is a simpleContent. This is likely impossible. -->
     <xs:complexType  name="FunctionTypeTDB">
     <xs:annotation>
         <xs:documentation>
             A TDB function, as copied from a TDB file.
         </xs:documentation>
     </xs:annotation>
-    <xs:simpleContent>
-        <xs:extension base="xs:string">
+    <xs:complexContent>
+        <xs:extension base="AbstractFunctionType">
+        <xs:sequence>
 
-            <xs:attribute name="name" use="required" type="FunctionIDType" />
-        </xs:extension>
-    </xs:simpleContent>
-    
+            <xs:element name="tdb" type="xs:string" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        A TDB function, as copied from a TDB file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:extension>
+    </xs:complexContent>
     </xs:complexType>   
 
+    <!-- As is, this can not inherit from the abstract Function Type, as it is a simpleContent. This is likely impossible. -->
     <xs:complexType  name="FunctionTypeCSdat">
     <xs:annotation>
         <xs:documentation>
@@ -137,12 +192,21 @@
             This will be ignored.
         </xs:documentation>
     </xs:annotation>
-    <xs:simpleContent>
-        <xs:extension base="xs:string">
+    <xs:complexContent>
+        <xs:extension base="AbstractFunctionType">
+        <xs:sequence>
 
-            <xs:attribute name="name" use="required" type="FunctionIDType" />
-        </xs:extension>
-    </xs:simpleContent>
-    </xs:complexType>   
+        <xs:element name="chemsage" type="xs:string" minOccurs="1" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                    A TDB function, as copied from a TDB file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:element>
+    </xs:sequence>
+</xs:extension>
+</xs:complexContent>
+</xs:complexType>   
+
 
 </xs:schema>

--- a/schema/phases/functions.xsd
+++ b/schema/phases/functions.xsd
@@ -19,12 +19,59 @@
         </xs:annotation>
         
             <xs:restriction base="xs:string">
+                <xs:enumeration value="expr" />
                 <xs:enumeration value="h-s-cp" />
                 <xs:enumeration value="tdb" />
                 <xs:enumeration value="CSdat" />
                 <xs:enumeration value="gibbs" />
             </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="FunctionTypeExprRange">
+        <xs:annotation>
+            <xs:documentation>
+                A range for a function that is stored in strict ThermML expression style.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            
+            <xs:extension base="xs:string">
+                <xs:attribute name="low" type="xs:double" use="required">
+                <xs:annotation>
+                    <xs:documentation>Lower range limit.</xs:documentation>
+                </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="high" type="xs:double" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    
+    </xs:complexType>
+
+    <xs:complexType name="FunctionReferenceType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Reference to a function that is a child of the functions element.
+            </xs:documentation>
+        </xs:annotation>
+            <xs:attribute name="type" use="required" type="FunctionType" />
+            <xs:attribute name="factor" use="optional" type="xs:float" default="1.0" />
+            <xs:attribute name="name" use="required" type="FunctionIDType" />
+    </xs:complexType>
+
+
+    <xs:complexType  name="FunctionTypeExpr">
+    <xs:annotation>
+        <xs:documentation>
+            A temperature dependent function that is stored in strict ThermML expression style.
+        </xs:documentation>
+        
+    </xs:annotation>
+    <xs:sequence>
+        <xs:element name="range" type="FunctionTypeExprRange" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="FunctionIDType" use="required" />
+    
+    </xs:complexType>   
 
     <xs:complexType name="FunctionHSCPTermType">
         <xs:annotation>

--- a/schema/phases/functions.xsd
+++ b/schema/phases/functions.xsd
@@ -1,0 +1,101 @@
+<xs:schema
+        targetNamespace="http://calphad.org/thermml/0.0"
+        elementFormDefault="qualified"
+        version="0.0"
+        xmlns="http://calphad.org/thermml/0.0"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:include schemaLocation="core.xsd" />
+    <xs:include schemaLocation="../simple-types/main.xsd" />
+
+
+
+
+    <xs:simpleType  name="FunctionType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A descriptor for different function types.
+            </xs:documentation>
+        </xs:annotation>
+        
+            <xs:restriction base="xs:string">
+                <xs:enumeration value="h-s-cp" />
+                <xs:enumeration value="tdb" />
+                <xs:enumeration value="CSdat" />
+                <xs:enumeration value="gibbs" />
+            </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="FunctionHSCPTermType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A term in a H-S-CP function.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="coeff" use="required" type="xs:double"/>
+        <xs:attribute name="fun" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType  name="FunctionTypeHSCP">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A H-S-CP function. 
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+        <xs:element name="h298">
+            <xs:complexType>
+              <xs:attribute name="value" type="xs:double" use="required"/>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="s298">
+            <xs:complexType>
+              <xs:attribute name="value" type="xs:double" use="required"/>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="Range" minOccurs="1" maxOccurs="unbounded" >
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="term" type="FunctionHSCPTermType" maxOccurs="unbounded"/>
+              </xs:sequence>
+              <xs:attribute name="low" type="xs:double" use="required"/>
+              <xs:attribute name="high" type="xs:double" use="required"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="FunctionIDType"/>
+    </xs:complexType>   
+
+    <xs:complexType  name="FunctionTypeTDB">
+    <xs:annotation>
+        <xs:documentation>
+            A TDB function, as copied from a TDB file.
+        </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+        <xs:extension base="xs:string">
+
+            <xs:attribute name="name" use="required" type="FunctionIDType" />
+        </xs:extension>
+    </xs:simpleContent>
+    
+    </xs:complexType>   
+
+    <xs:complexType  name="FunctionTypeCSdat">
+    <xs:annotation>
+        <xs:documentation>
+            A ChemSage.dat function, as can be copied from a file.
+
+            The first row may contain additional stoichiometric information.
+            This will be ignored.
+        </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+        <xs:extension base="xs:string">
+
+            <xs:attribute name="name" use="required" type="FunctionIDType" />
+        </xs:extension>
+    </xs:simpleContent>
+    </xs:complexType>   
+
+</xs:schema>

--- a/schema/phases/functions.xsd
+++ b/schema/phases/functions.xsd
@@ -1,0 +1,101 @@
+<xs:schema
+        targetNamespace="http://calphad.org/thermml/0.0"
+        elementFormDefault="qualified"
+        version="0.0"
+        xmlns="http://calphad.org/thermml/0.0"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:include schemaLocation="core.xsd" />
+    <xs:include schemaLocation="../simple-types/main.xsd" />
+
+
+
+
+    <xs:simpleType  name="FunctionType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A descriptor for different function types.
+            </xs:documentation>
+        </xs:annotation>
+        
+            <xs:restriction base="xs:string">
+                <xs:enumeration value="h-s-cp" />
+                <xs:enumeration value="tdb" />
+                <xs:enumeration value="CSdat" />
+                <xs:enumeration value="gibbs" />
+            </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="FunctionHSCPTermType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A term in a H-S-CP function.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="coeff" use="required" type="xs:double"/>
+        <xs:attribute name="fun" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType  name="FunctionTypeHSCP">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A H-S-CP function. 
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+        <xs:element name="h298">
+            <xs:complexType>
+              <xs:attribute name="value" type="xs:double" use="required"/>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="s298">
+            <xs:complexType>
+              <xs:attribute name="value" type="xs:double" use="required"/>
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="range" minOccurs="1" maxOccurs="unbounded" >
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="term" type="FunctionHSCPTermType" maxOccurs="unbounded"/>
+              </xs:sequence>
+              <xs:attribute name="low" type="xs:double" use="required"/>
+              <xs:attribute name="high" type="xs:double" use="required"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="FunctionIDType"/>
+    </xs:complexType>   
+
+    <xs:complexType  name="FunctionTypeTDB">
+    <xs:annotation>
+        <xs:documentation>
+            A TDB function, as copied from a TDB file.
+        </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+        <xs:extension base="xs:string">
+
+            <xs:attribute name="name" use="required" type="FunctionIDType" />
+        </xs:extension>
+    </xs:simpleContent>
+    
+    </xs:complexType>   
+
+    <xs:complexType  name="FunctionTypeCSdat">
+    <xs:annotation>
+        <xs:documentation>
+            A ChemSage.dat function, as can be copied from a file.
+
+            The first row may contain additional stoichiometric information.
+            This will be ignored.
+        </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+        <xs:extension base="xs:string">
+
+            <xs:attribute name="name" use="required" type="FunctionIDType" />
+        </xs:extension>
+    </xs:simpleContent>
+    </xs:complexType>   
+
+</xs:schema>

--- a/schema/phases/pure-substances.xsd
+++ b/schema/phases/pure-substances.xsd
@@ -19,30 +19,33 @@
                             </xs:sequence>
                         </xs:complexType>
                     </xs:element>
-                    <xs:choice>
-
-                        <xs:element name="energyRef">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
-                                    The energy function for the phase.
-                                </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                            <xs:attribute name="type" use="required" type="FunctionType" />
-                            <xs:attribute name="factor" use="optional" type="xs:float" default="1.0" />
-                            <xs:attribute name="name" use="required" type="FunctionIDType" />
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="energy" >
-                            <xs:complexType>
+                    <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            
+                            <xs:choice>
+                                <xs:element name="reference">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            Reference to a function that resides elsewhere.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                    <xs:complexType>
+                                        <xs:attribute name="type" use="required" type="FunctionType" />
+                                        <xs:attribute name="factor" use="optional" type="xs:float" default="1.0" />
+                                        <xs:attribute name="name" use="required" type="FunctionIDType" />
+                                    </xs:complexType>
+                                </xs:element>
                                 <xs:choice minOccurs="1" maxOccurs="1">        
                                     <xs:element name="hscp" type="FunctionTypeHSCP"/>
                                     <xs:element name="tdb" type="FunctionTypeTDB"/>
                                     <xs:element name="chemsage" type="FunctionTypeCSdat"/>
                                 </xs:choice>
-                            </xs:complexType>                            
-                        </xs:element>
-                    </xs:choice>
+                            </xs:choice>
+                            <xs:attribute name="type" use="required" type="PhasePropertyType" />
+                            <xs:attribute name="function_of" use="required" type="FunctionVariableType" />
+
+                        </xs:complexType>
+                    </xs:element>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/schema/phases/pure-substances.xsd
+++ b/schema/phases/pure-substances.xsd
@@ -6,6 +6,7 @@
         xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:include schemaLocation="core.xsd" />
+    <xs:include schemaLocation="functions.xsd" />
 
     <xs:complexType name="PurePhaseType">
         <xs:complexContent>
@@ -16,6 +17,18 @@
                             <xs:sequence minOccurs="1" maxOccurs="unbounded">
                                 <xs:element name="stoich" type="StoichiometryRecordType" />
                             </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="energy">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                The energy function for the phase.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                        <xs:attribute name="type" use="required" type="FunctionType" />
+                        <xs:attribute name="factor" use="optional" type="xs:float" default="1.0" />
+                        <xs:attribute name="name" use="required" type="FunctionIDType" />
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>

--- a/schema/phases/pure-substances.xsd
+++ b/schema/phases/pure-substances.xsd
@@ -28,16 +28,12 @@
                         <xs:complexType>
                             <xs:choice>
                                 <xs:element name="reference" type="FunctionReferenceType"/>
-                                <xs:choice minOccurs="1" maxOccurs="1">        
-                                    <xs:element name="expr" type="FunctionTypeExpr"/>
-                                    <xs:element name="hscp" type="FunctionTypeHSCP"/>
-                                    <xs:element name="tdb" type="FunctionTypeTDB"/>
-                                    <xs:element name="chemsage" type="FunctionTypeCSdat"/>
+                                <xs:choice minOccurs="1" maxOccurs="1">  
+                                    <xs:element name="function" type="AbstractFunctionType"/>      
                                 </xs:choice>
                             </xs:choice>
                             <xs:attribute name="type" use="required" type="PhasePropertyType" />
                             <xs:attribute name="function_of" use="optional" type="FunctionVariableType" />
-
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>

--- a/schema/phases/pure-substances.xsd
+++ b/schema/phases/pure-substances.xsd
@@ -6,6 +6,7 @@
         xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:include schemaLocation="core.xsd" />
+    <xs:include schemaLocation="functions.xsd" />
 
     <xs:complexType name="PurePhaseType">
         <xs:complexContent>
@@ -18,6 +19,30 @@
                             </xs:sequence>
                         </xs:complexType>
                     </xs:element>
+                    <xs:choice>
+
+                        <xs:element name="energyRef">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    The energy function for the phase.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                            <xs:attribute name="type" use="required" type="FunctionType" />
+                            <xs:attribute name="factor" use="optional" type="xs:float" default="1.0" />
+                            <xs:attribute name="name" use="required" type="FunctionIDType" />
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="energy" >
+                            <xs:complexType>
+                                <xs:choice minOccurs="1" maxOccurs="1">        
+                                    <xs:element name="hscp" type="FunctionTypeHSCP"/>
+                                    <xs:element name="tdb" type="FunctionTypeTDB"/>
+                                    <xs:element name="chemsage" type="FunctionTypeCSdat"/>
+                                </xs:choice>
+                            </xs:complexType>                            
+                        </xs:element>
+                    </xs:choice>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/schema/phases/pure-substances.xsd
+++ b/schema/phases/pure-substances.xsd
@@ -20,29 +20,23 @@
                         </xs:complexType>
                     </xs:element>
                     <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                A property of the phase, e.g. Gibbs energy, enthalpy, Bohr magneton, ...
+                            </xs:documentation>
+                        </xs:annotation>
                         <xs:complexType>
-                            
                             <xs:choice>
-                                <xs:element name="reference">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            Reference to a function that resides elsewhere.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                    <xs:complexType>
-                                        <xs:attribute name="type" use="required" type="FunctionType" />
-                                        <xs:attribute name="factor" use="optional" type="xs:float" default="1.0" />
-                                        <xs:attribute name="name" use="required" type="FunctionIDType" />
-                                    </xs:complexType>
-                                </xs:element>
+                                <xs:element name="reference" type="FunctionReferenceType"/>
                                 <xs:choice minOccurs="1" maxOccurs="1">        
+                                    <xs:element name="expr" type="FunctionTypeExpr"/>
                                     <xs:element name="hscp" type="FunctionTypeHSCP"/>
                                     <xs:element name="tdb" type="FunctionTypeTDB"/>
                                     <xs:element name="chemsage" type="FunctionTypeCSdat"/>
                                 </xs:choice>
                             </xs:choice>
                             <xs:attribute name="type" use="required" type="PhasePropertyType" />
-                            <xs:attribute name="function_of" use="required" type="FunctionVariableType" />
+                            <xs:attribute name="function_of" use="optional" type="FunctionVariableType" />
 
                         </xs:complexType>
                     </xs:element>

--- a/schema/system-components/main.xsd
+++ b/schema/system-components/main.xsd
@@ -8,21 +8,10 @@
     <xs:simpleType name="SystemComponentIdType">
         <xs:annotation>
             <xs:documentation xml:lang="en">
-                A unique identifier for system componet.
+                An identifier for system component, typically an element of the periodic table.
             </xs:documentation>
         </xs:annotation>
-        <xs:restriction base="xs:ID">
-            <xs:pattern value="[A-Z][a-z]?" />
-        </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="SystemComponentIdRefType">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                A unique identifier reference for system componet.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:restriction base="xs:IDREF">
+        <xs:restriction base="xs:string">
             <xs:pattern value="[A-Z][a-z]?" />
         </xs:restriction>
     </xs:simpleType>
@@ -33,7 +22,6 @@
                 The most basic component from which phase constituents are constructed.
             </xs:documentation>
         </xs:annotation>
-        <!-- <xs:attribute name="id"          type="SystemComponentIdType"  use="required"/> -->
         <xs:attribute name="symbol"      type="SystemComponentIdType"              use="required">
             <xs:annotation>
                 <xs:documentation xml:lang="en">

--- a/schema/system-components/main.xsd
+++ b/schema/system-components/main.xsd
@@ -12,7 +12,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:ID">
-            <xs:pattern value="cmp[A-Z][a-z]?" />
+            <xs:pattern value="[A-Z][a-z]?" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -23,7 +23,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:IDREF">
-            <xs:pattern value="cmp[A-Z][a-z]?" />
+            <xs:pattern value="[A-Z][a-z]?" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -33,8 +33,8 @@
                 The most basic component from which phase constituents are constructed.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="id"          type="SystemComponentIdType"  use="required"/>
-        <xs:attribute name="symbol"      type="xs:string"              use="required">
+        <!-- <xs:attribute name="id"          type="SystemComponentIdType"  use="required"/> -->
+        <xs:attribute name="symbol"      type="SystemComponentIdType"              use="required">
             <xs:annotation>
                 <xs:documentation xml:lang="en">
                     A symbol used for display purposes.


### PR DESCRIPTION
I've been finally able to write up some suggestions. Feel free to challenge my decisions!

My suggestion encompasses:

1. 'vendor' specific functions should be as easily as possible copied from existing databases. That means that we get TDD and ChemSage.dat specific *function* nodes. I would suggest these as transitive elements, to ease migration. My idea would be that the format should be able to ingress this type of function nodes, but at least in e.g. my implementation, I would only support the h-s-cp format for output. I think this decision will be fruitful both in situations for manual conversion/manipulation of databases, as well as testing and general acceptance (e.g. if one can demonstratively "show" that the function blocks are convertable in that regard, this is great for integrity.

2. I removed the 'cmpXX' id type for system components (and will like to follow up on this with some of the other IDs, depending on your feedback). I think the validation of these IDs can be realized identically, given with the changes that I implemented. I simply don't see the advantage of separating the name and ID of a system component, as I can't see a scenario where this would be warranted.

3. Had a look at how pycalphad employs the ascii<->AST conversion of TDBs, and especially for output. As long as there is no general support of e.g. SymEngine's style (and I also do not know if this allows lossless roundtrips?), I am hard pressed how to find a good-enough and fairly-straight conversion of the polynoms. MathML is basically unreadable, even though it is fully able to express the types of functions I encountered. XML-internal validation is likely out of the window anyways. I settled on the h-s-cp version, which goes somewhere in between everything - but it allows much less nesting or more complex expressions (e.g. `A*B*T`). Similar to how the Fact universe works, it also only allows functions to be referenced as linear factors in any term, not e.g. as exponent or argument to symbolic expressions. Very open to suggestions!
4. Does anyone see an issue with using `<energy>` for the expression? It feels slightly off to me. Let me know if you have better ideas.

Known issues (not mainline to this PR, feel free to add issues or spin off branches to discuss)
* String validations for names etc are still a bit all over the place.
* Function ID needs to be properly set to IDREF type for validation.
* Punting the whitespace formatting and more detailed documentation for now. Will try to fix this before merging.
* The template hierarchy and especially the places where 'type' definitions are kept will need to be overhauled.
* It may be needed to revisit the "pure phase" denomination, given the fuzzy edges of some definitions.